### PR TITLE
Scale the point size of systems by their population

### DIFF
--- a/app/views/main.html
+++ b/app/views/main.html
@@ -5,13 +5,14 @@
 	<footer></footer>
 	<script type="x-shader/x-vertex" id="vertexshader">
 			attribute vec3 customColor;
+			attribute float aSize;
 			uniform float size;
 			uniform float scale;
 			varying vec3 vColor;
 			void main() {
 				vColor = customColor;
         vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
-        gl_PointSize = size * ( scale / length( mvPosition.xyz ) );
+        gl_PointSize = aSize * ( scale / length( mvPosition.xyz ) );
         gl_Position = projectionMatrix * mvPosition;
 			}
 		</script>


### PR DESCRIPTION
These changes will scale the point size of systems based on their population. Systems with 0 or null data will keep the point size they had before (100) while systems with populations greater than 1 billion will start to scale this number up. 

The base selection circle radius was scaled down and is multiplied with the point size scaling, so it should always encompass the selected system's point with a little extra room to spare.

The shader uniform 'size' can probably be dropped but I've left it in, it just isn't used anymore.