### PR TITLE
Scale the point size of systems by their population

### DIFF
--- a/app/scripts/directives/edSystemMap/edSystemMap.js
+++ b/app/scripts/directives/edSystemMap/edSystemMap.js
@@ -120,6 +120,7 @@ angular.module('edGalaxyMap')
 						geometry.addAttribute( 'position', new THREE.BufferAttribute( positions, 3 ) );
 						geometry.addAttribute( 'customColor', new THREE.BufferAttribute( colors, 3 ) );
 						geometry.addAttribute( 'aSize', new THREE.BufferAttribute( sizes, 1 ) );
+						geometry.attributes.aSize.needsUpdate = true;
 
 						particleSystem = new THREE.Points( geometry, shaderMaterial );
 

--- a/app/views/main.html
+++ b/app/views/main.html
@@ -5,13 +5,14 @@
 	<footer></footer>
 	<script type="x-shader/x-vertex" id="vertexshader">
 			attribute vec3 customColor;
+			attribute float aSize;
 			uniform float size;
 			uniform float scale;
 			varying vec3 vColor;
 			void main() {
 				vColor = customColor;
         vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );
-        gl_PointSize = size * ( scale / length( mvPosition.xyz ) );
+        gl_PointSize = aSize * ( scale / length( mvPosition.xyz ) );
         gl_Position = projectionMatrix * mvPosition;
 			}
 		</script>


### PR DESCRIPTION
Previous pull request didn't mark the aSize BufferAttribute as ```needsUpdate```, this was causing invalid data in the vertex shader. 

It's strange that customColor seems to work without this flag but the sizes are working for me in Firefox and Chrome now. Let me know how it looks there.